### PR TITLE
Retry video fetch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,12 @@ VERSION = open(os.path.join(BASEDIR, 'VERSION')).read().strip()
 
 # Dependencies (format is 'PYPI_PACKAGE_NAME[>=]=VERSION_NUMBER')
 BASE_DEPENDENCIES = [
-    'wf-honeycomb_io>=0.2.0',
-    'wf-cv-utils>=2.0.0',
-    'opencv-python>=4.5.1',
+    'wf-honeycomb_io>=2.0.0',
+    'wf-cv-utils>=3.4.0',
+    'opencv-python>=4.6.0',
     'jmespath',
     'tenacity',
+    'urllib3',
     'wf_fastapi_auth0>=1.0',
 ]
 

--- a/video_io/client.py
+++ b/video_io/client.py
@@ -154,11 +154,11 @@ class VideoStorageClient:
             try:
                 response = self.request_session.request(**request)
                 response.raise_for_status()
-                if response.status_code == 200:
-                    pp = p.parent
-                    if not pp.exists():
-                        pp.mkdir(parents=True, exist_ok=True)
-                    p.write_bytes(response.content)
+
+                pp = p.parent
+                if not pp.exists():
+                    pp.mkdir(parents=True, exist_ok=True)
+                p.write_bytes(response.content)
                 logger.info('Video file %s finished downloading', path)
             except requests.exceptions.HTTPError as e:
                 logger.error('Failing fetching video file %s with HTTP error code %s', path, e.response.status_code)
@@ -197,9 +197,9 @@ class VideoStorageClient:
         try:
             response = requests.request(**request)
             response.raise_for_status()
-            if response.status_code == 200:
-                data = response.json()
-                return data
+
+            data = response.json()
+            return data
         except requests.exceptions.HTTPError as e:
             logger.error('Failing fetching video metadata for %s from %s to %s with HTTP error code %s', environment_id, start_date, end_date, e.response.status_code)
             raise e

--- a/video_io/client.py
+++ b/video_io/client.py
@@ -118,7 +118,7 @@ class VideoStorageClient:
         retry_strategy = LogRetry(
             total=6,
             status_forcelist=[429, 500, 502, 503, 504],
-            method_whitelist=["HEAD", "GET", "OPTIONS"],
+            method_whitelist=["HEAD", "GET", "OPTIONS", "POST"],
             backoff_factor=0.5
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)

--- a/video_io/log_retry.py
+++ b/video_io/log_retry.py
@@ -1,0 +1,12 @@
+import logging
+
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger(__name__)
+
+
+class LogRetry(Retry):
+    def increment(self, method=None, url=None, *args, **kwargs):
+        new_retry = super().increment(*args, **kwargs)
+        logger.warning("Incremented Retry for (method=%s) (url='%s'), %r", method, url, new_retry)
+        return new_retry


### PR DESCRIPTION
I've integrated `urllib3` retries into the video fetching client. There were a couple of POST functions in the client that used an @retry decorator. For consistency, I'm suggesting using a single "retry" approach, if possible. Take a look @optimuspaul  and see what you think.